### PR TITLE
fail validation gracefully on missing metadata

### DIFF
--- a/src/validateAssistant.js
+++ b/src/validateAssistant.js
@@ -9,9 +9,7 @@ function validateAssistantBody () {
 function validateAssistantMedia () {
   const all = new ValidationObj();
 
-  const response = {
-    all,
-  };
+  const response = { all };
 
   // No validation for now
 

--- a/src/validateFacebook.js
+++ b/src/validateFacebook.js
@@ -1,4 +1,5 @@
 const get = require('lodash/get');
+const isObject = require('lodash/isObject');
 
 const ValidationObj = require('./ValidationObj');
 const validateUrl = require('./validateUrl');
@@ -61,6 +62,7 @@ const FACEBOOK_VIDEO_EXTENSIONS = [
 // video (in use): https://developers.facebook.com/docs/graph-api/reference/page/videos
 // image: https://developers.facebook.com/docs/graph-api/photo-uploads
 function validateFacebookMetadata (metadata) {
+  console.log(metadata);
   const validationObj = new ValidationObj();
 
   const { extension, size, duration } = metadata;
@@ -94,10 +96,13 @@ function validateFacebookMetadata (metadata) {
 
 function validateFacebookMedia (media) {
   const all = new ValidationObj();
-  const response = {
-    all,
-  };
+  const response = { all };
   if (media) {
+    if (media.some(instance => !isObject(instance.metadata))) {
+      all.add_error('Media metadata analysis unavailable. Please check back later.');
+      return response;
+    }
+
     const img_count = media.filter(instance => FACEBOOK_IMAGE_EXTENSIONS.includes(instance.metadata.extension)).length;
     const video_count = media.filter(instance => FACEBOOK_VIDEO_EXTENSIONS.includes(instance.metadata.extension)).length;
     // if(img_count > 4) all.add_error('Only 4 images can be attached to a facebook post at this time.');

--- a/src/validateGoogleMyBusiness.js
+++ b/src/validateGoogleMyBusiness.js
@@ -1,4 +1,5 @@
 const get = require('lodash/get');
+const isObject = require('lodash/isObject');
 
 const ValidationObj = require('./ValidationObj');
 
@@ -99,19 +100,20 @@ function validateGMBDetails (details) {
 function validateGMBMedia (media) {
   const all = new ValidationObj();
 
+  const response = { all };
+
   if (!media || media.length !== 1) {
     all.add_error('Must include exactly 1 image to post to Google My Business');
   } else {
-    const metadata = media[0].metadata;
-    const { extension } = metadata;
-    if (!SUPPORTED_IMAGE_EXTENSIONS.includes(extension)) {
+    if (media.some(instance => !isObject(instance.metadata))) {
+      all.add_error('Media metadata analysis unavailable. Please check back later.');
+      return response;
+    }
+
+    if (!SUPPORTED_IMAGE_EXTENSIONS.includes(media[0].metadata.extension)) {
       all.add_error(`Unsupported file type. Must be one of ${SUPPORTED_IMAGE_EXTENSIONS.join(', ')}`);
     }
   }
-
-  const response = {
-    all,
-  };
 
   return response;
 }

--- a/src/validateInstagram.js
+++ b/src/validateInstagram.js
@@ -1,7 +1,9 @@
-const ValidationObj = require('./ValidationObj');
-const crossStreams = require('./crossStreams');
 const get = require('lodash/get');
 const isEmpty = require('lodash/isEmpty');
+const isObject = require('lodash/isObject');
+
+const ValidationObj = require('./ValidationObj');
+const crossStreams = require('./crossStreams');
 const { threadRegex } = require('./regex');
 
 const SUPPORTED_IMAGE_EXTENSIONS = [
@@ -92,11 +94,14 @@ function validateInstagramMedia (media) {
   if (!media || media.length === 0) all.add_error('Must include at least 1 image/video to automatically post to Instagram.');
   if (media.length > 10) all.add_error('Maximum of 10 images/videos to automatically post to Instagram');
 
-  const response = {
-    all,
-  };
+  const response = { all };
 
   if (media && media.length) {
+    if (media.some(instance => !isObject(instance.metadata))) {
+      all.add_error('Media metadata analysis unavailable. Please check back later.');
+      return response;
+    }
+
     for (const instance of media) {
       response[instance.id] = validateInstagramMetadata(instance.metadata);
     }

--- a/src/validatePinterest.js
+++ b/src/validatePinterest.js
@@ -1,3 +1,5 @@
+const isObject = require('lodash/isObject');
+
 const ValidationObj = require('./ValidationObj');
 const crossStreams = require('./crossStreams');
 const urlRegex = require('./urlRegex');
@@ -38,17 +40,22 @@ function validatePinterestMetadata (metadata) {
 
 function validatePinterestMedia (media) {
   const all = new ValidationObj();
-  if (media.length < 1) {
-    all.add_error('Pinterest requires that an image be attached to each pin.');
-  }
-  if (media.length > 1) {
-    all.add_error('Only 1 image can be attached to a pin.');
-  }
-  const response = {
-    all,
-  };
-  for (const instance of media) {
-    response[instance.id] = validatePinterestMetadata(instance.metadata);
+  const response = { all };
+  if (media) {
+    if (media.some(instance => !isObject(instance.metadata))) {
+      all.add_error('Media metadata analysis unavailable. Please check back later.');
+      return response;
+    }
+
+    if (media.length < 1) {
+      all.add_error('Pinterest requires that an image be attached to each pin.');
+    }
+    if (media.length > 1) {
+      all.add_error('Only 1 image can be attached to a pin.');
+    }
+    for (const instance of media) {
+      response[instance.id] = validatePinterestMetadata(instance.metadata);
+    }
   }
   return response;
 }

--- a/src/validateYoutube.js
+++ b/src/validateYoutube.js
@@ -1,3 +1,5 @@
+const isObject = require('lodash/isObject');
+
 const ValidationObj = require('./ValidationObj');
 const crossStreams = require('./crossStreams');
 
@@ -56,14 +58,20 @@ function validateYoutubeMetadata (metadata) {
 
 function validateYoutubeMedia (media) {
   const all = new ValidationObj();
-  const video_count = media.filter(instance => SUPPORTED_VIDEO_EXTENSIONS.includes(instance.metadata.extension)).length;
-  if (video_count > 1) all.add_error('Only 1 video can be uploaded to youtube at a time.');
-  if (video_count < 1) all.add_error('Youtube posts require a video.');
-  const response = {
-    all,
-  };
-  for (const instance of media) {
-    response[instance.id] = validateYoutubeMetadata(instance.metadata);
+  const response = { all };
+  if (media) {
+    if (media.some(instance => !isObject(instance.metadata))) {
+      all.add_error('Media metadata analysis unavailable. Please check back later.');
+      return response;
+    }
+
+    const video_count = media.filter(instance => SUPPORTED_VIDEO_EXTENSIONS.includes(instance.metadata.extension)).length;
+    if (video_count > 1) all.add_error('Only 1 video can be uploaded to youtube at a time.');
+    if (video_count < 1) all.add_error('Youtube posts require a video.');
+
+    for (const instance of media) {
+      response[instance.id] = validateYoutubeMetadata(instance.metadata);
+    }
   }
   return response;
 }


### PR DESCRIPTION
Since these functions can now be called from the frontend, there's a possibility of attempting to validate a post before the `upload-service` has had a chance to parse the metadata. This will prevent crashing and false negatives in that case.