### PR TITLE
Jm/instagram reels

### DIFF
--- a/src/validateFacebook.js
+++ b/src/validateFacebook.js
@@ -6,12 +6,14 @@ const validateUrl = require('./validateUrl');
 const validateLinkImage = require('./validateLinkImage');
 const crossStreams = require('./crossStreams');
 
-function validateFacebookBody (body, hasMedia = false) {
+function validateFacebookBody (body, postContentType, hasMedia = false) {
   const maxCharacters = 63206;
   const validationObj = new ValidationObj();
 
   if (!hasMedia && (!body || typeof body !== 'string' || !body.length)) validationObj.add_error('Must have a body');
   if (body.length > maxCharacters) validationObj.add_error('too long');
+
+  if (postContentType === 'reel') validationObj.add_warning('Facebook does not support Reels. This post will be published as a normal post.');
 
   return validationObj;
 }
@@ -133,7 +135,7 @@ function validate_facebook (post, integration) {
   return {
     integration: integration.id,
     platform: integration.platform,
-    body: validateFacebookBody(post.body, Boolean(post.media && post.media.length)),
+    body: validateFacebookBody(post.body, post.post_content_type, Boolean(post.media && post.media.length)),
     media: validateFacebookMedia(post.media),
     link: validateUrl(post.link_url),
     link_image_url: validateLinkImage(post.link_image_url, post.is_link_preview_customized, post.platform),

--- a/src/validateGoogleMyBusiness.js
+++ b/src/validateGoogleMyBusiness.js
@@ -26,12 +26,14 @@ const SUPPORTED_IMAGE_EXTENSIONS = [
   '.png',
 ];
 
-function validateGMBBody (body) {
+function validateGMBBody (body, postContentType) {
   const maxCharacters = 1500;
   const validationObj = new ValidationObj();
 
   if (!body || typeof body !== 'string') validationObj.errors.push({ message: 'GMB requires a summary for every post' });
   if (body.length > maxCharacters) validationObj.errors.push({ message: 'Summary is too long' });
+
+  if (postContentType === 'reel') validationObj.add_warning('GMB does not support Reels. This post will be published as a normal post.');
 
   return validationObj;
 }
@@ -122,7 +124,7 @@ function validate_google_my_business (post, integration) {
   return {
     integration: integration.id,
     platform: integration.platform,
-    body: validateGMBBody(post.body),
+    body: validateGMBBody(post.body, post.post_content_type),
     details: validateGMBDetails(post.details),
     media: validateGMBMedia(post.media),
   };

--- a/src/validateLinkedin.js
+++ b/src/validateLinkedin.js
@@ -7,12 +7,14 @@ const crossStreams = require('./crossStreams');
 
 const LINKEDIN_MAX_CONTIGUOUS_SIZE = 200 * 1024 * 1024;
 
-function validateLinkedinBody (body, media) {
+function validateLinkedinBody (body, media, postContentType) {
   const maxCharacters = 3000;
   const validationObj = new ValidationObj();
 
   if ((!body && (!media || !media.length)) || typeof body !== 'string') validationObj.errors.push({ message: 'no content' });
   if (body.length > maxCharacters) validationObj.errors.push({ message: `only ${maxCharacters} characters allowed` });
+
+  if (postContentType === 'reel') validationObj.add_warning('LinkedIn does not support Reels. This post will be published as a normal post.');
 
   return validationObj;
 }
@@ -119,7 +121,7 @@ function validate_linkedin (post, integration) {
   return {
     integration: integration.id,
     platform: integration.platform,
-    body: validateLinkedinBody(post.body, post.media),
+    body: validateLinkedinBody(post.body, post.media, post.post_content_type),
     media: validateLinkedinMedia(post.media, post.link_url),
     link: validateUrl(post.link_url),
     link_caption: validateLinkedinLinkCaption(post.link_caption),

--- a/src/validatePinterest.js
+++ b/src/validatePinterest.js
@@ -7,12 +7,14 @@ const validateUrl = require('./validateUrl');
 const validateLinkImage = require('./validateLinkImage');
 const MAX_NOTE_LENGTH = 500;
 
-function validatePinterestBody (body) {
+function validatePinterestBody (body, postContentType) {
   const validationObj = new ValidationObj();
 
   if (body.length > MAX_NOTE_LENGTH) validationObj.add_error('Note too long', MAX_NOTE_LENGTH, body.length);
 
   if (body.match(urlRegex)) validationObj.add_error('pinterest post bodies cannot contain urls');
+
+  if (!postContentType === 'reel') validationObj.add_warning('Pinterest does not support Reels. This post will be published as a normal post.');
 
   return validationObj;
 }
@@ -75,7 +77,7 @@ function validate_pinterest (post, integration) {
     integration: integration.id,
     platform: integration.platform,
     // title: validatePinterestTitle(post.title),
-    body: validatePinterestBody(post.body),
+    body: validatePinterestBody(post.body, post.post_content_type),
     link: validatePinterestLink(post.link_url),
     media: validatePinterestMedia(post.media),
     link_image_url: validateLinkImage(post.link_image_url, post.is_link_preview_customized, post.platform),

--- a/src/validateTwitter.js
+++ b/src/validateTwitter.js
@@ -12,7 +12,7 @@ const { threadRegex } = require('./regex');
 
 // TODO: check if they text they are wanting to send is the same as the text in their last tweet
 
-function validateTwitterBody (body, hasMedia = false) {
+function validateTwitterBody (body, postContentType, hasMedia = false) {
   const parsedTweet = parseTweet(body);
 
   const validationObj = new ValidationObj();
@@ -38,6 +38,8 @@ function validateTwitterBody (body, hasMedia = false) {
   while ((result = invalidChars.exec(body))) { // eslint-disable-line no-cond-assign
     validationObj.add_error('Invalid character', result.index, result.index + result.length);
   }
+
+  if (postContentType === 'reel') validationObj.add_warning('Twitter does not support Reels. This post will be published as a normal tweet.');
 
   return validationObj;
 }
@@ -163,7 +165,7 @@ function validate_twitter (post, integration) {
   return {
     integration: integration.id,
     platform: integration.platform,
-    body: validateTwitterBody(post.body, Boolean(post.media && post.media.length)),
+    body: validateTwitterBody(post.body, post.post_content_type, Boolean(post.media && post.media.length)),
     link: validateUrl(post.link_url),
     media: validateTwitterMedia(post.media),
     link_image_url: validateLinkImage(post.link_image_url, post.is_link_preview_customized, post.platform),

--- a/src/validateYoutube.js
+++ b/src/validateYoutube.js
@@ -16,11 +16,13 @@ function validateYoutubeTitle (title) {
   return validationObj;
 }
 
-function validateYoutubeBody (body) {
+function validateYoutubeBody (body, postContentType) {
   const validationObj = new ValidationObj();
 
   if (!body || typeof body !== 'string') validationObj.add_error('Must have a body');
   if (body.length > MAX_DESCRIPTION_LENGTH) validationObj.add_error('Description too long', 0, body.length);
+
+  if (!postContentType === 'reel') validationObj.add_warning('YouTube Shorts is not supported. This post will be published as a normal video.');
 
   return validationObj;
 }
@@ -81,7 +83,7 @@ function validate_youtube (post, integration) {
     integration: integration.id,
     platform: integration.platform,
     title: validateYoutubeTitle(post.title),
-    body: validateYoutubeBody(post.body),
+    body: validateYoutubeBody(post.body, post.post_content_type),
     media: validateYoutubeMedia(post.media),
   };
 }


### PR DESCRIPTION
# Instagram Reels
https://reputation.atlassian.net/browse/RBENT-80815

Related PRs: 
https://github.com/nuvi/app/pull/4030
https://github.com/nuvi/graph-api/pull/3064
https://github.com/nuvi/publishing-service/pull/599

When an instagram integration is selected for a post, there should now be the option to choose whether to publish as a regular post or as a reel:
<img width="647" alt="Screen Shot 2022-08-17 at 2 33 31 PM" src="https://user-images.githubusercontent.com/13909995/185238388-5a12fba9-7da1-4424-9f0c-903fdbc82dbc.png">

Instagram Reels have a different set of validation requirements (found [here](https://developers.facebook.com/docs/instagram-api/reference/ig-user/media#reel-specifications)): 
* Container: MOV or MP4 (MPEG-4 Part 14), no edit lists, moov atom at the front of the file.
* Audio codec: AAC, 48khz sample rate maximum, 1 or 2 channels (mono or stereo).
* Video codec: HEVC or H264, progressive scan, closed GOP, 4:2:0 chroma subsampling.
* Frame rate: 23-60 FPS.
* Picture size:
     * Maximum columns (horizontal pixels): 1920
     * Required aspect ratio is between 0.01:1 and 10:1 but we recommend 9:16 to avoid cropping or blank spaces.
* Video bitrate: VBR, 5Mbps maximum
* Audio bitrate: 128kbps
* Duration: 15 mins maximum, 3 seconds minimum
* File size: 100MB maximum
